### PR TITLE
Enable custom label name; Add macOS support

### DIFF
--- a/src/kobuddy/__init__.py
+++ b/src/kobuddy/__init__.py
@@ -35,11 +35,11 @@ DATABASES: List[Path] = []
 # e.g. if you delete book from device, hightlights/bookmarks just disappear
 
 
-def set_databases(dbp: Optional[Union[Path, str]]):
+def set_databases(dbp: Optional[Union[Path, str]], label='KOBOeReader'):
     if dbp is None:
-        mount = get_kobo_mountpoint()
+        mount = get_kobo_mountpoint(label=label)
         if mount is None:
-            raise RuntimeError("Coulnd't find mounted Kobo device, are you sure it's connected? (perhaps try using different label?)")
+            raise RuntimeError(f"Coulnd't find mounted Kobo device with label '{label}', are you sure it's connected? (perhaps try using different label?)")
         db = mount / '.kobo' / 'KoboReader.sqlite'
         @contextmanager
         def tmp_db():
@@ -252,7 +252,7 @@ class ProgressEvent(OtherEvent):
     def summary(self) -> str:
         return 'reading' + self.verbose
 
-    # TODO FIXME use progress event instead? 
+    # TODO FIXME use progress event instead?
 class StartEvent(OtherEvent):
     @property
     def summary(self) -> str:
@@ -856,7 +856,7 @@ def _load_highlights(bfile: Path, books: Books):
         book = books.by_content_id(volumeid)
         assert book is not None
         # TODO make defensive?
-        # TODO could be example of useful defensiveness in a provider 
+        # TODO could be example of useful defensiveness in a provider
         yield Highlight(bm, book=book)
 
 def get_highlights(**kwargs) -> List[Highlight]:
@@ -1003,4 +1003,3 @@ def print_annotations():
 """.strip('\n')
         print(h)
         print("------")
-

--- a/src/kobuddy/__main__.py
+++ b/src/kobuddy/__main__.py
@@ -37,6 +37,7 @@ By default will try to read the database from your Kobo device.
 If you pass a directory, will try to use all Kobo databases it can find.
     ''', required=False)
     p.add_argument('--errors', choices=['throw', 'return'], default='throw', help="throw: raise on errors immediately; return: handle defensively long as possible and reasonable")
+    p.add_argument('--label', default='KOBOeReader', help="device label (check lsblk if default doesn't work)")
     sp = p.add_subparsers(dest='mode')
     sp.add_parser('books'      , help='print all books')
     sp.add_parser('progress'   , help='print all book reading progress')
@@ -57,7 +58,7 @@ Alternatively, you can add a udev rule or something similar.
         kobuddy.backup.run(args)
         return
 
-    with set_databases(args.db):
+    with set_databases(args.db, label=args.label):
         if args.mode == 'progress':
             print_progress(errors=args.errors)
         elif args.mode == 'books':

--- a/src/kobuddy/kobo_device.py
+++ b/src/kobuddy/kobo_device.py
@@ -1,18 +1,24 @@
 import json
 from pathlib import Path
-from subprocess import check_output
+import subprocess
 from typing import Optional
 
 
 def get_kobo_mountpoint(label: str='KOBOeReader') -> Optional[Path]:
-    xxx = check_output(['lsblk', '-f', '--json']).decode('utf8')
-    jj = json.loads(xxx)
-    kobos = [d for d in jj['blockdevices'] if d.get('label', None) == label]
+    try:  # Linux
+        xxx = subprocess.check_output(['lsblk', '-f', '--json']).decode('utf8')
+        jj = json.loads(xxx)
+        kobos = [d for d in jj['blockdevices'] if d.get('label', None) == label]
+        kobos = [k['mountpoint'] for k in kobos]
+    except FileNotFoundError:  # macOS (does not have lsblk)
+        output = subprocess.check_output(('df', '-Hl')).decode('utf8')
+        output = [o.split() for o in output.split('\n')]
+        kobos = [o[-1] for o in output if f'/Volumes/{label}' in o]
+
     if len(kobos) > 1:
         raise RuntimeError(f'Multiple Kobo devices detected: {kobos}')
     elif len(kobos) == 0:
         return None
     else:
         [kobo] = kobos
-        return Path(kobo['mountpoint'])
-
+        return Path(kobo)


### PR DESCRIPTION
Added the ability to run all subcommands with a custom label name, e.g.:

```bash
kobuddy --label MyKobo-Name books
kobuddy --label MyKobo-Name progress
```

Added support for **macOS**